### PR TITLE
Make agnostic the templating engine

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,9 +10,7 @@
     "o-colors": ">=2.0.0 <4",
     "o-assets": ">=2.0.0 <4",
     "o-overlay": "^1.4.5",
-    "o-fonts": "^2.1.2",
-    
-    "hogan": "git+https://github.com/twitter/hogan.js.git#^3.0.2"
+    "o-fonts": "^2.1.2"
   },
   "ignore": [
     "node_modules",

--- a/main.js
+++ b/main.js
@@ -11,7 +11,6 @@ exports.utils = require('./src/javascripts/utils.js');
 
 exports.i18n = require('./src/javascripts/i18n.js');
 exports.templates = require('./src/javascripts/templates.js');
-exports.templatingEngine = require('./src/javascripts/templatingEngine.js');
 
 /**
  * Enables logging.

--- a/src/javascripts/overlay_content_builder/OverlayFormContent.js
+++ b/src/javascripts/overlay_content_builder/OverlayFormContent.js
@@ -1,15 +1,13 @@
-const templatingEngine = require('../templatingEngine');
-
 const templates = require('../templates.js');
 
 const utils = require('../utils.js');
 const formFragments = require('./formFragments.js');
 
-const errorMessageContainerTemplate = templatingEngine.compile(require('../../templates/form/errorMessageContainer.html'));
-const buttonContainerTemplate = templatingEngine.compile(require('../../templates/form/buttonContainer.html'));
-const buttonTemplate = templatingEngine.compile(require('../../templates/form/button.html'));
-const buttonCancelTemplate = templatingEngine.compile(require('../../templates/form/buttonCancel.html'));
-const dismissTemplate = templatingEngine.compile(require('../../templates/form/dismiss.html'));
+const errorMessageContainerTemplate = require('../../templates/form/errorMessageContainer.html');
+const buttonContainerTemplate = require('../../templates/form/buttonContainer.html');
+const buttonTemplate = require('../../templates/form/button.html');
+const buttonCancelTemplate = require('../../templates/form/buttonCancel.html');
+const dismissTemplate = require('../../templates/form/dismiss.html');
 const clearTemplate = templates.clearLine;
 
 /**
@@ -77,7 +75,7 @@ function OverlayFormContent (config) {
 
 		container.appendChild(formObject);
 
-		formObject.appendChild(utils.toDOM(errorMessageContainerTemplate.render()));
+		formObject.appendChild(utils.toDOM(errorMessageContainerTemplate()));
 
 
 		if (config.items && config.items.length) {
@@ -93,7 +91,7 @@ function OverlayFormContent (config) {
 		}
 
 		if (config.buttons && config.buttons.length) {
-			formObject.appendChild(utils.toDOM(buttonContainerTemplate.render()));
+			formObject.appendChild(utils.toDOM(buttonContainerTemplate()));
 			const buttonContainer = formObject.querySelector('.o-comment-ui--overlay-button-container');
 
 			for (i = 0; i < config.buttons.length; i++) {
@@ -102,33 +100,33 @@ function OverlayFormContent (config) {
 				switch(button.type) {
 					case 'button':
 						if (typeof button.label !== "undefined" && button.label) {
-							buttonContainer.appendChild(utils.toDOM(buttonTemplate.render({
+							buttonContainer.appendChild(utils.toDOM(buttonTemplate({
 								type: 'button',
 								label: button.label
 							})));
 						}
 						break;
 					case 'submitButton':
-						buttonContainer.appendChild(utils.toDOM(buttonTemplate.render({
+						buttonContainer.appendChild(utils.toDOM(buttonTemplate({
 							type: 'submit',
 							label: button.label ? button.label : 'Submit'
 						})));
 						break;
 					case 'cancelButton':
-						buttonContainer.appendChild(utils.toDOM(buttonCancelTemplate.render({
+						buttonContainer.appendChild(utils.toDOM(buttonCancelTemplate({
 							label: button.label ? button.label : 'cancel'
 						})));
 						break;
 					case 'dismiss':
 						if (typeof button.label !== "undefined" && button.label) {
-							buttonContainer.appendChild(utils.toDOM(dismissTemplate.render({
+							buttonContainer.appendChild(utils.toDOM(dismissTemplate({
 								label: button.label
 							})));
 						}
 				}
 			}
 
-			formObject.appendChild(utils.toDOM(clearTemplate.render()));
+			formObject.appendChild(utils.toDOM(clearTemplate()));
 
 			const cancelButtons = formObject.querySelectorAll('.o-comment-ui--cancel-button');
 			const triggerCancel = function () {

--- a/src/javascripts/overlay_content_builder/formFragments.js
+++ b/src/javascripts/overlay_content_builder/formFragments.js
@@ -1,19 +1,17 @@
-const templatingEngine = require('../templatingEngine');
-
-const fieldsetTemplate = templatingEngine.compile(require('../../templates/formFragments/fieldset.html'));
-const pseudonymTemplate = templatingEngine.compile(require('../../templates/formFragments/pseudonym.html'));
-const emailSettingsTemplate = templatingEngine.compile(require('../../templates/formFragments/emailSettings.html'));
-const explanationTemplate = templatingEngine.compile(require('../../templates/formFragments/explanation.html'));
-const sessionExpiredTemplate = templatingEngine.compile(require('../../templates/formFragments/sessionExpired.html'));
+const fieldsetTemplate = require('../../templates/formFragments/fieldset.html');
+const pseudonymTemplate = require('../../templates/formFragments/pseudonym.html');
+const emailSettingsTemplate = require('../../templates/formFragments/emailSettings.html');
+const explanationTemplate = require('../../templates/formFragments/explanation.html');
+const sessionExpiredTemplate = require('../../templates/formFragments/sessionExpired.html');
 
 /**
  * Form fragment that contains setting the initial pseudonym.
  * @return {String} Mustache template
  */
 exports.initialPseudonym = function () {
-	return fieldsetTemplate.render({
+	return fieldsetTemplate({
 		legend: 'Pseudonym',
-		content: pseudonymTemplate.render({
+		content: pseudonymTemplate({
 			name: 'pseudonym',
 			label: 'In order to use the commenting system, please choose a pseudonym.',
 			currentPseudonym: ''
@@ -27,9 +25,9 @@ exports.initialPseudonym = function () {
  * @return {String} Mustache template
  */
 exports.changePseudonym = function (config) {
-	return fieldsetTemplate.render({
+	return fieldsetTemplate({
 		legend: 'Pseudonym',
-		content: pseudonymTemplate.render({
+		content: pseudonymTemplate({
 			name: 'pseudonym',
 			label: 'This is displayed with your comments. If you change it, previous '+
 				'comments will also be attributed to the new pseudonym.',
@@ -52,7 +50,7 @@ const emailSettingsForm = function (config) {
 	config.emailreplies = config.emailreplies || "immediately";
 	config.emaillikes = config.emaillikes || "never";
 
-	return emailSettingsTemplate.render({
+	return emailSettingsTemplate({
 		selects: [
 			{
 				name: 'emailreplies',
@@ -134,7 +132,7 @@ const emailSettingsForm = function (config) {
  * @return {String} Mustache template
  */
 exports.emailSettings = function (config) {
-	return fieldsetTemplate.render({
+	return fieldsetTemplate({
 		legend: 'Email Settings',
 		content: 'Receive alerts when:<br/>' + emailSettingsForm(config.currentSettings)
 	});
@@ -146,7 +144,7 @@ exports.emailSettings = function (config) {
  * @return {String} Mustache template
  */
 exports.emailSettingsStandalone = function (config) {
-	return fieldsetTemplate.render({
+	return fieldsetTemplate({
 		legend: 'Email Settings',
 		content: emailSettingsForm(config.currentSettings)
 	});
@@ -157,7 +155,7 @@ exports.emailSettingsStandalone = function (config) {
  * @return {String} Mustache template
  */
 exports.followExplanation = function () {
-	return explanationTemplate.render({
+	return explanationTemplate({
 		text: 'To receive email alerts about conversations that you\'re interested in, '+
 			'click the \'follow\' button that now appears on the comment box.',
 		type: 'follow'
@@ -169,7 +167,7 @@ exports.followExplanation = function () {
  * @return {String} Mustache template
  */
 exports.commentingSettingsExplanation = function () {
-	return explanationTemplate.render({
+	return explanationTemplate({
 		text: 'You can manage your settings in the Commenting settings panel above the comment box.',
 		type: 'settings'
 	});
@@ -180,7 +178,7 @@ exports.commentingSettingsExplanation = function () {
  * @return {String} Mustache template
  */
 exports.sessionExpired = function () {
-	return sessionExpiredTemplate.render({
+	return sessionExpiredTemplate({
 		location: encodeURIComponent(document.location.href)
 	});
 };

--- a/src/javascripts/templates.js
+++ b/src/javascripts/templates.js
@@ -1,14 +1,12 @@
-const templatingEngine = require('./templatingEngine');
-
 /**
  * Mustache templates, compiled but not rendered.
  * @type {Object}
  */
 module.exports = {
-	unavailableTemplate: templatingEngine.compile(require('../templates/unavailable.html')),
-	authUnavailableTemplate: templatingEngine.compile(require('../templates/authUnavailable.html')),
-	termsAndGuidelinesTemplate: templatingEngine.compile(require('../templates/termsAndGuidelines.html')),
-	clearLine: templatingEngine.compile(require('../templates/clearLine.html')),
-	commentingSettingsLink: templatingEngine.compile(require('../templates/commentingSettingsLink.html')),
-	environmentDisplay: templatingEngine.compile(require('../templates/environmentDisplay.html')),
+	unavailableTemplate: require('../templates/unavailable.html'),
+	authUnavailableTemplate: require('../templates/authUnavailable.html'),
+	termsAndGuidelinesTemplate: require('../templates/termsAndGuidelines.html'),
+	clearLine: require('../templates/clearLine.html'),
+	commentingSettingsLink: require('../templates/commentingSettingsLink.html'),
+	environmentDisplay: require('../templates/environmentDisplay.html')
 };

--- a/src/javascripts/templatingEngine.js
+++ b/src/javascripts/templatingEngine.js
@@ -1,3 +1,0 @@
-const hogan = require('hogan');
-
-module.exports = hogan;


### PR DESCRIPTION
Through using the generic `require` approach.  That is, `require('foobar.html')` will return the compiled version of the template.

To setup server-side:

```
// hook up .html to Handlebars
require('handlebars');
require.extensions['.html'] = require.extensions['.handlebars'];
```

and client-side:

```
			{
				test: /\.html$/,
				loader: 'handlebars'
			}
```

note that, obviously, for the server-side you'd need to do a `npm install --save handlebars` and for the client-side, `npm install --save handlebars-loader`.

### Browserify

If you use `browserify` instead of `webpack`, see:

https://github.com/epeli/node-hbsfy

and here for an example:

https://github.com/epeli/node-hbsfy/blob/master/example/index.js

### Other building systems

Google for "Handlebars" along with your building system name.  Usually there'll be a plugin to allow you to simply `require('template.html')` to get the compiled template.