### PR TITLE
Avoid using document object upon being imported/required

### DIFF
--- a/src/javascripts/i18n.js
+++ b/src/javascripts/i18n.js
@@ -10,7 +10,7 @@ exports.texts = {
 	commentingSettingsLabel: 'Commenting settings'
 };
 
-var invalidSession;
+let invalidSession;
 /**
  * Error messages coming from the web services could be not user friendly.
  * So some of the messages are mapped to a more user friendly message.

--- a/src/javascripts/i18n.js
+++ b/src/javascripts/i18n.js
@@ -10,14 +10,23 @@ exports.texts = {
 	commentingSettingsLabel: 'Commenting settings'
 };
 
+var invalidSession;
 /**
  * Error messages coming from the web services could be not user friendly.
  * So some of the messages are mapped to a more user friendly message.
  * @type {Object}
  */
 exports.serviceMessageOverrides = {
-	'User session is not valid.': 'You are not currently signed in to FT.com, please '+
-			'<a href="https://accounts.ft.com/login?location='+ encodeURIComponent(document.location.href) +'">sign in</a> to create a pseudonym',
+	set 'User session is not valid.' (message) {
+		invalidSession = message;
+	},
+	get 'User session is not valid.' () {
+		if (!invalidSession) {
+			invalidSession = 'You are not currently signed in to FT.com, please '+
+			'<a href="https://accounts.ft.com/login?location='+ encodeURIComponent(document.location.href) +'">sign in</a> to create a pseudonym';
+		}
+		return invalidSession;
+	},
 	'User profile (.*) does not have permission to access the desired action.': 'You don\'t have permission to perform this action.',
 	'Commenting is closed for conversation=([0-9]+)': 'This conversation is closed to new comments.'
 };


### PR DESCRIPTION
Delay the reading of the document object by using a getter method instead of a property. We've kept the ability to override the invalid session message by also adding a setter method.