### PR TITLE
Upgrade dependencies to the latest major release.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,11 +6,11 @@
   ],
   "dependencies": {
     "o-comment-utilities": "^2.2.0",
-    "o-icons": ">=4.0.0 <6",
-    "o-colors": "^4.0.0",
-    "o-assets": ">=2.0.0 <4",
-    "o-overlay": "^2.0.0",
-    "o-fonts": "^3.0.0",
+    "o-icons": "^6.0.0",
+    "o-colors": "^5.0.2",
+    "o-assets": "^3.4.2",
+    "o-overlay": "^3.0.0",
+    "o-fonts": "^4.0.0",
     "hogan": "^3.0.2"
   },
   "ignore": [

--- a/main.scss
+++ b/main.scss
@@ -10,12 +10,14 @@ $o-overlay-is-silent: false;
 @import 'o-fonts/main';
 
 @if $o-comment-ui-include-fonts == true {
-	// @font-face declarations for all Benton Sans weights
-	@include oFontsInclude(MetricWeb, light);
-	@include oFontsInclude(MetricWeb, regular);
-	@include oFontsInclude(MetricWeb, bold);
+	@include oFonts($opts: (
+		'metric': (
+	        ('weight': 'light', 'style': 'normal'),
+	        ('weight': 'regular', 'style': 'normal'),
+	        ('weight': 'bold', 'style': 'normal'),
+	    )
+	));
 }
-
 
 @import './src/stylesheets/buttons';
 @import './src/stylesheets/icons';

--- a/src/javascripts/userDialogs/changePseudonymDialog.js
+++ b/src/javascripts/userDialogs/changePseudonymDialog.js
@@ -1,5 +1,5 @@
+import Overlay from 'o-overlay';
 const OverlayFormContent = require('../overlay_content_builder/OverlayFormContent.js');
-const Overlay = require('o-overlay');
 
 let shown = false;
 

--- a/src/javascripts/userDialogs/emailAlertDialog.js
+++ b/src/javascripts/userDialogs/emailAlertDialog.js
@@ -1,4 +1,4 @@
-const Overlay = require('o-overlay');
+import Overlay from 'o-overlay';
 const OverlayFormContent = require('../overlay_content_builder/OverlayFormContent.js');
 
 let shown = false;

--- a/src/javascripts/userDialogs/inactivityMessageDialog.js
+++ b/src/javascripts/userDialogs/inactivityMessageDialog.js
@@ -1,4 +1,4 @@
-const Overlay = require('o-overlay');
+import Overlay from 'o-overlay';
 const OverlayFormContent = require('../overlay_content_builder/OverlayFormContent.js');
 
 let shown = false;

--- a/src/javascripts/userDialogs/setPseudonymDialog.js
+++ b/src/javascripts/userDialogs/setPseudonymDialog.js
@@ -1,4 +1,4 @@
-const Overlay = require('o-overlay');
+import Overlay from 'o-overlay';
 const OverlayFormContent = require('../overlay_content_builder/OverlayFormContent.js');
 const oCommentUtilities = require('o-comment-utilities');
 

--- a/src/javascripts/userDialogs/settingsDialog.js
+++ b/src/javascripts/userDialogs/settingsDialog.js
@@ -1,4 +1,4 @@
-const Overlay = require('o-overlay');
+import Overlay from 'o-overlay';
 const OverlayFormContent = require('../overlay_content_builder/OverlayFormContent.js');
 
 let shown = false;

--- a/src/stylesheets/commentingSettingsLink.scss
+++ b/src/stylesheets/commentingSettingsLink.scss
@@ -1,17 +1,17 @@
 .o-comment-ui--settings {
 	display: inline-block;
 	margin-left: 10px;
-	color: oColorsGetPaletteColor("black-20");
+	color: oColorsByName("black-20");
 
 	.o-comment-ui--settings-text {
 		padding-left: 10px;
-		color: oColorsGetPaletteColor("oxford");
+		color: oColorsByName("oxford");
 		cursor: pointer;
 		display: inline-block;
 	}
 
 	.o-comment-ui--settings-icon {
-		@include oIconsGetIcon('settings', oColorsGetPaletteColor('oxford'), 25, $iconset-version: 1);
+		@include oIconsContent('settings', oColorsByName('oxford'), $size: 25);
 		vertical-align: bottom;
 	}
 }

--- a/src/stylesheets/icons.scss
+++ b/src/stylesheets/icons.scss
@@ -1,5 +1,5 @@
 .o-comment-ui--icon-lock {
-	@include oIconsGetIcon('lock', oColorsGetPaletteColor("black-70"), 15, $iconset-version: 1);
+	@include oIconsContent('lock', oColorsByName("black-70"), $size: 15);
 
 	display: inline-block;
 }


### PR DESCRIPTION
This bumps `o-comment-ui` dependencies but does not 
remove CommonJS etc, because o-comment-ui _is truly_
going away soon.